### PR TITLE
clean: rename link to the 3scale-sre github org

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,5 +1,5 @@
 module "ec2_labels" {
-  source      = "git@github.com:3scale-ops/tf-aws-label.git?ref=tags/0.1.2"
+  source      = "git@github.com:3scale-sre/tf-aws-label.git?ref=tags/0.1.2"
   environment = local.environment
   project     = local.project
   workload    = local.workload

--- a/elasticache.tf
+++ b/elasticache.tf
@@ -1,5 +1,5 @@
 module "ec_labels" {
-  source      = "git@github.com:3scale-ops/tf-aws-label.git?ref=tags/0.1.2"
+  source      = "git@github.com:3scale-sre/tf-aws-label.git?ref=tags/0.1.2"
   environment = local.environment
   project     = local.project
   workload    = local.workload


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup
/kind documentation

### What this PR does / why we need it:
Updates all links to point to the 3scale-sre org after the migration.

### Notes
/kind cleanup
/kind documentation
/assign
/priority important-longterm